### PR TITLE
upgrade with new boot2docker image (docker 1.3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,6 @@ MAINTAINER damien.duportal@gmail.com
 
 RUN rm -f boot2docker.iso
 
-######## VirtualBox Guest Additions building
-# You can change the target version here
-ENV VBOX_VERSION 4.3.14
-
-RUN apt-get install -y p7zip-full
-
-RUN mkdir -p /vboxguest && \
-    cd /vboxguest && \
-    curl -L -o vboxguest.iso http://download.virtualbox.org/virtualbox/${VBOX_VERSION}/VBoxGuestAdditions_${VBOX_VERSION}.iso && \
-    7z x vboxguest.iso -ir'!VBoxLinuxAdditions.run' && \
-    sh VBoxLinuxAdditions.run --noexec --target . && \
-    mkdir x86 && cd x86 && tar xvjf ../VBoxGuestAdditions-x86.tar.bz2 && cd .. && \
-    mkdir amd64 && cd amd64 && tar xvjf ../VBoxGuestAdditions-amd64.tar.bz2 && cd .. && \
-    cd amd64/src/vboxguest-${VBOX_VERSION} && KERN_DIR=/linux-kernel/ make && cd ../../.. && \
-    cp amd64/src/vboxguest-${VBOX_VERSION}/*.ko $ROOTFS/lib/modules/$KERNEL_VERSION-tinycore64 && \
-    mkdir -p $ROOTFS/sbin && cp x86/lib/VBoxGuestAdditions/mount.vboxsf $ROOTFS/sbin/
-
-# Adding freshly built kernel module
-RUN depmod -a -b $ROOTFS $KERNEL_VERSION-tinycore64
-# We need to load the module when b2d is booting.
-RUN echo "modprobe vboxsf" >> $ROOTFS/opt/bootsync.sh
-
-
 ####### Vagrant customisation
 
 # This script will :wq

--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-B2D_VERSION="v1.2.0"
+B2D_VERSION="v1.3.0"
 TAG=""
 
 while getopts ":s" opt; do


### PR DESCRIPTION
I just removed guest addition (already done in the new b2d image, v4.3.18) and change version number.

The main question remain about security, the b2d image start docker using tcp://2376.
It's a bit frustrating. Using 
export DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
in /var/lib/boot2docker/profile does the trick but maybe it should be integrated in the box ?

Regards

Pouic
