### PR TITLE
add NFS support and rewrite bootlocal.sh proccess

### DIFF
--- a/b2d-provision.sh
+++ b/b2d-provision.sh
@@ -34,18 +34,7 @@ tar cf ${B2D_PERSISTENT_DIR}/userdata.tar ./.ssh
 
 ## I want to re-use the bootlocal.sh stuff, but adding one optionnaly from the /vagrant folder
 cat <<EOF >${B2D_PERSISTENT_DIR}/bootlocal.sh
-# Waiting for /vagrant to be mounted
-while true; do
-    if [[ -d /vagrant ]]; then
-       break
-    fi
-    sleep 1
-done
-sleep 5
+sudo /usr/local/etc/init.d/nfs-client start
 
-# If we have a bootlocal.sh in /vagrant, just run it
-if [[ -x /vagrant/bootlocal.sh ]]; then
-	/bin/sh /vagrant/bootlocal.sh
-fi
 EOF
 sudo chmod a+x ${B2D_PERSISTENT_DIR}/bootlocal.sh

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -6,6 +6,11 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
   config.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
 
+  # Add bootlocal support
+  if File.file?('./bootlocal.sh')
+    config.vm.provision "shell", path: "bootlocal.sh", run: "always"
+  end
+
   # Attach the ISO
   config.vm.provider "virtualbox" do |v|
     v.customize "pre-boot", [


### PR DESCRIPTION
Hey,

## NFS

In order to be able to use NFS for `synced_folder` i've add `nfs-client` start command in bootlocal.sh

To use `NFS`, add `type: "nfs"` to your `synced_folder`.

```
config.vm.synced_folder ".", "/vagrant", type: "nfs"
```

## Bootlocal

When we want to execute commands when `/vagrant` is mounted, we can use `SYSTEM-V` but, vagrant provision run when folders are mounted.

So we can simply use a `config.vm.provision "shell", path: "bootlocal.sh", run: "always"`.

If something more complicated is needed,you can add rules when filesystems are mounted:

`in /etc/udev/rules.d/` create a new file like `50-vagrant-mounts.rules`
```
# Start on mount
SUBSYSTEM=="bdi",ACTION=="add",RUN+="/do/something'"
# Stop on unmount
SUBSYSTEM=="bdi",ACTION=="remove",RUN+="/do/somehting/else'"
```
If you want to use `bootlocal.sh` in a fresh project, you just need to create a file next to the vagrantfile.

## Common issue

When using vagrant `1.7.x` with ensecure key, vagrant will replace this key by a new one. It's throw error when reloading the box (`Warning: Authentication failure. Retrying...`).

To resolve this little issue, simply add: `config.ssh.insert_key = false` to your Vagrantfile.

## Tricks
To make docker client working with a private networked docker server you need to add in your `bootlocal.sh`:

```
/usr/local/etc/init.d/docker restart
cp -r /var/lib/boot2docker/tls /vagrant/
```
Next, you need to export cert path: `export DOCKER_CERT_PATH=$PWD/tls`


See ya.