### PR TITLE
add default network id to vagrantfile

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -10,7 +10,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
 
   # Create a private network for accessing VM without NAT
-  config.vm.network "private_network", ip: "192.168.10.10"
+  config.vm.network "private_network", ip: "192.168.10.10", id: "default-network"
 
   # Add bootlocal support
   if File.file?('./bootlocal.sh')


### PR DESCRIPTION
Hey,

If we don't have an id on `config.vm.network` we can't override it.

```
# Root vagrant file
config.vm.network "private_network", ip: "192.168.10.10"

# Client vagrant file
config.vm.network "private_network", ip: "192.168.10.69"
```
So, if i define a private_network as `192.168.10.69`, docker will not generate certificates for `192.168.10.69`.

We don't want that.

if we simply add:

```
config.vm.network "private_network", ip: "192.168.10.69", id: "default-network"
```

Certificates are well generated with the right network addr.

Ps: We need to try it with other networks too. Didn't have time now but maybe soon.