### PR TITLE
Making NFS working + Docker 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 13/05/2015 (v1.6.1)
+- Moving boot2docker to 1.6.1 : https://github.com/boot2docker/boot2docker/releases/tag/v1.6.1
+- GH-10 : Making NFS working, environment variable powered
+
 ## 04/05/2015 (v1.6.0)
 - Moving boot2docker to 1.6.0 : https://github.com/boot2docker/boot2docker/releases/tag/v1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 
 ## 13/05/2015 (v1.6.1)
 - Moving boot2docker to 1.6.1 : https://github.com/boot2docker/boot2docker/releases/tag/v1.6.1
-- GH-10 : Making NFS working, environment variable powered
+- GH-10 : Making NFS working, environment variable powered, documentation added
+- Corrections around the Makefile for building yourself
 
 ## 04/05/2015 (v1.6.0)
 - Moving boot2docker to 1.6.0 : https://github.com/boot2docker/boot2docker/releases/tag/v1.6.0

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,16 @@ boot2docker.iso:
 
 test: test-virtualbox
 
-test-virtualbox:
+test-virtualbox: clean-test-virtualbox
 	@cd tests/virtualbox; bats --tap *.bats
 
-clean:
+clean: clean-build clean-test
+
+clean-build:
 	rm -rf *.iso *.box
+
+clean-test-virtualbox:
+	@cd tests/virtualbox;vagrant destroy -f
+	rm -rf tests/*/Vagrantfile tests/*/.vagrant
 
 .PHONY: clean prepare build test test-virtualbox

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,17 @@
 BOOT2DOCKER_VERSION = 1.6.1
 
+all: clean build test
+
 build: boot2docker.iso
 	time (packer build -parallel=false template.json)
-
-prepare: clean boot2docker.iso
 
 boot2docker.iso:
 	curl -L -o boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v$(BOOT2DOCKER_VERSION)/boot2docker.iso
 
-test: test-virtualbox
-
-test-virtualbox: clean-test-virtualbox
+test:
 	@cd tests/virtualbox; bats --tap *.bats
 
-clean: clean-build clean-test
-
-clean-build:
+clean:
 	rm -rf *.iso *.box
 
-clean-test-virtualbox:
-	@cd tests/virtualbox;vagrant destroy -f
-	rm -rf tests/*/Vagrantfile tests/*/.vagrant
-
-.PHONY: clean prepare build test test-virtualbox
+.PHONY: clean build test all

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+BOOT2DOCKER_VERSION = 1.6.1
+
 build: boot2docker.iso
 	time (packer build -parallel=false template.json)
 
 prepare: clean boot2docker.iso
 
 boot2docker.iso:
-	curl -L -o boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v1.6.0/boot2docker.iso
+	curl -L -o boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v$(BOOT2DOCKER_VERSION)/boot2docker.iso
 
 test: test-virtualbox
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,37 @@
 # boot2docker Vagrant Box
 
 This repository contains the scripts necessary to create a Vagrant-compatible
-[boot2docker](https://github.com/boot2docker/boot2docker) box and is compatible with Docker v1.5. 
+[boot2docker](https://github.com/boot2docker/boot2docker) box and is compatible with Docker v1.6. 
 
-If you work solely
-with Docker, this box lets you keep your Vagrant workflow and work in the
-most minimal Docker environment possible.
+If you work solely with Docker, this box lets you keep your Vagrant workflow and work in the most minimal Docker environment possible.
 
 ## Usage
 
-The box is available on
-[Vagrant Cloud](https://vagrantcloud.com/dduportal/boot2docker), making
-it very easy to use it:
+The box is available on [Hashicrop's Atlas](https://atlas.hashicorp.com/dduportal/boxes/boot2docker), making it very easy to use it:
 
     $ vagrant init dduportal/boot2docker
     $ vagrant up
 
-If you want the actual box file, you can download it from the
-[tags page](https://github.com/dduportal/boot2docker-vagrant-box/tags).
+If you want the actual box source file, you can download it from the [tags page](https://github.com/dduportal/boot2docker-vagrant-box/tags).
 
-On OS X, to use the docker client, follow the directions here:
-http://docs.docker.io/installation/mac/#docker-os-x-client (you'll need to
-export `DOCKER_HOST`). You should then be able to to run `docker version` from
-the host.
+On OS X, to use the docker client, follow the directions here: http://docs.docker.io/installation/mac/#docker-os-x-client (you'll need to export `DOCKER_HOST`). You should then be able to to run `docker version` from the host. [Homebrew](http://brew.sh) can also a good installation medium with ```brew update && brew install docker```
 
-![Vagrant Up Boot2Docker](https://raw.github.com/mitchellh/boot2docker-vagrant-box/master/readme_image.gif)
 
 ## Tips & tricks
 
 * Vagrant synced folder has been tested with :
-  * vbox shared folder
-  * NFS
+  * vbox shared folder : This is default sharing system
+  * [rsync](https://docs.vagrantup.com/v2/synced-folders/rsync.html) : add this line to your Vagrantfile (it will overwrite the default vboxsf sync behaviour) :
+
+    ```ruby
+config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    ```
+  * [NFS](https://docs.vagrantup.com/v2/synced-folders/nfs.html) : For now, use environment variable to enable NFS (Mac OS and Linux tested). It will ask for your admin password.
+
+    ```bash
+    $ export B2D_NFS_SYNC=1
+    $ vagrant up
+    ```
 
 * If you want to tune contents (custom profile, install tools inside the VM) that do not fit into the "vagrant provisionning" lifecycle combinded with the un-persistence of boot2docker, the "bootlocal" system has been extended :
   * The [boot2docker FaQ](https://github.com/boot2docker/boot2docker/blob/master/doc/FAQ.md) says that you can provide a custom script, named bootlocal.sh to execute things at the end of the boot.
@@ -60,10 +61,11 @@ do so in seconds.
 
 To build the box, first install the following prerequisites:
 
-  * [Packer](http://www.packer.io) (at least version 0.7.2)
-  * [VirtualBox](http://www.virtualbox.org) (at least version 4.3), VMware, or Parallels
-  * [Make](http://www.gnu.org/software/make/)
-  * [wget](http://www.gnu.org/software/wget/)
+  * [Make as workflow engine](http://www.gnu.org/software/make/)
+  * [Packer as vagrant basebox builder](http://www.packer.io) (at least version 0.7.5)
+  * [VirtualBox as main virtualization system](http://www.virtualbox.org) (at least version 4.3.28) [VMware and Parallels not implemented yet]
+  * [curl for downloading things](http://curl.haxx.se)
+  * [bats for testing](https://github.com/sstephenson/bats)
 
 Then follow the steps:
 

--- a/scripts/build-custom-iso.sh
+++ b/scripts/build-custom-iso.sh
@@ -41,6 +41,9 @@ for TCZ_PACKAGE in popt rsync; do
 	umount "${MNT_TMP_DIR}"
 done
 
+# Add option to the /opt/bootlocal.sh script
+echo "/usr/local/etc/init.d/nfs-client start" | tee -a "${EXTRACT_DIR}/opt/bootlocal.sh"
+
 # Generate the new initrd.img in new iso dir
 cd "${EXTRACT_DIR}"
 find | cpio -o -H newc | xz -9 --format=lzma > "${NEW_ISO_DIR}/boot/initrd.img"

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
     },
     "variables": {
         "B2D_ISO_FILE": "boot2docker.iso",
-        "B2D_ISO_CHECKSUM": "11f28ce5f9d1b7d7e3dc59d411b40065"
+        "B2D_ISO_CHECKSUM": "c59f70b4990d77f91ace7213935d69ee"
     },
     "builders": [{
         "type": "virtualbox-iso",

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -56,7 +56,7 @@
 @test "We shave a NFS synced folder if B2D_NFS_SYNC is set (admin password required, will fail on Windows)" {
 	export B2D_NFS_SYNC=1
 	vagrant reload
-	[ $(vagrant ssh -c 'df -h /vagrant/ | grep vagrant | grep "192.168.10.1"' -- -n -T) -ge 1 ]
+	[ $(vagrant ssh -c 'df -h /vagrant | grep vagrant | grep 192.168.10.1 | wc -l' -- -n -T) -ge 1 ]
 	unset B2D_NFS_SYNC
 }
 

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -37,13 +37,28 @@
 	vagrant ssh -c 'echo OK'
 }
 
-@test "We have a default synced folder thru vboxsf" {
+@test "We can share folder thru vboxsf" {
 	vagrant ssh -c "ls -l /vagrant/Vagrantfile"
 }
 
 @test "Rsync is installed inside the b2d" {
 	vagrant ssh -c "which rsync"
 }
+
+@test "The NFS client is started inside the VM" {
+	[ $(vagrant ssh -c 'ps aux | grep rpc.statd | wc -l' -- -n -T) -eq 1 ]
+}
+
+@test "We shave a default synced folder thru NFS if B2D_NFS_SYNC is set" {
+	export B2D_NFS_SYNC=1
+	sed '/synced_folder/d' vagrantfile.orig > Vagrantfile
+	vagrant destroy -f
+	vagrant up
+}
+
+# @test "We shave a default synced folder thru vboxsf instead of NFS if NO_B2D_NFS_SYNC is set" {
+	
+# }
 
 @test "We can share folder thru rsync" {
 	sed 's/"virtualbox"/"rsync"/g' vagrantfile.orig > Vagrantfile

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -24,10 +24,6 @@
 	vagrant ssh -c 'which docker'
 }
 
-@test "Docker remote service is started (init point of view)" {
-	vagrant ssh -c 'sudo /etc/init.d/docker status'
-}
-
 @test "Docker is working inside the remote VM " {
 	vagrant ssh -c 'docker ps'
 }

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -46,22 +46,22 @@
 }
 
 @test "The NFS client is started inside the VM" {
-	[ $(vagrant ssh -c 'ps aux | grep rpc.statd | wc -l' -- -n -T) -eq 1 ]
+	[ $(vagrant ssh -c 'ps aux | grep rpc.statd | wc -l' -- -n -T) -ge 1 ]
 }
 
-@test "We shave a default synced folder thru NFS if B2D_NFS_SYNC is set" {
+@test "We shave a default synced folder thru vboxsf instead of NFS if NO_B2D_NFS_SYNC is set" {
+	[ $(vagrant ssh -c 'df -h /vagrant | grep vagrant | grep none | wc -l' -- -n -T) -ge 1 ]
+}
+
+@test "We shave a NFS synced folder if B2D_NFS_SYNC is set (admin password required, will fail on Windows)" {
 	export B2D_NFS_SYNC=1
-	sed '/synced_folder/d' vagrantfile.orig > Vagrantfile
-	vagrant destroy -f
-	vagrant up
+	vagrant reload
+	[ $(vagrant ssh -c 'df -h /vagrant/ | grep vagrant | grep "192.168.10.1"' -- -n -T) -ge 1 ]
+	unset B2D_NFS_SYNC
 }
-
-# @test "We shave a default synced folder thru vboxsf instead of NFS if NO_B2D_NFS_SYNC is set" {
-	
-# }
 
 @test "We can share folder thru rsync" {
-	sed 's/"virtualbox"/"rsync"/g' vagrantfile.orig > Vagrantfile
+	sed 's/#SYNC_TOKEN/config.vm.synced_folder ".", "\/vagrant", type: "rsync"/g' vagrantfile.orig > Vagrantfile
 	vagrant reload
 	[ $( vagrant status | grep 'running' | wc -l ) -ge 1 ]
 	vagrant ssh -c "ls -l /vagrant/Vagrantfile"

--- a/tests/virtualbox/vagrantfile.orig
+++ b/tests/virtualbox/vagrantfile.orig
@@ -8,6 +8,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "boot2docker-virtualbox-test"
   config.vm.box_url = "file://../../boot2docker_virtualbox.box"
   
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  #SYNC_TOKEN
 
 end

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   # Use NFS folder sync by default unless we are on Windows
-  if !ENV['NO_B2D_NFS_SYNC'] && (ENV['B2D_NFS_SYNC'] || !Vagrant::Util::Platform.windows?)
+  if ENV['B2D_NFS_SYNC']
     config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ["nolock", "vers=3", "udp"], id: "nfs-sync"
   end
 

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -5,6 +5,11 @@ Vagrant.configure("2") do |config|
   # Used on Vagrant >= 1.7.x to disable the ssh key regeneration
   config.ssh.insert_key = false
 
+  # Use NFS folder sync by default unless we are on Windows
+  if !ENV['NO_B2D_NFS_SYNC'] && (ENV['B2D_NFS_SYNC'] || !Vagrant::Util::Platform.windows?)
+    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ["nolock", "vers=3", "udp"], id: "nfs-sync"
+  end
+
   # Expose the Docker ports (non secured AND secured)
   config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
   config.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"


### PR DESCRIPTION
This PR introduce :
* Update to docker and boot2docker 1.6.1
* Making NFS working and enabled thru environment variable. The env. var will be subject to change since it is not homogeneous with the rsync part.
* Doc. updated