### PR TITLE
Switch to virtio NIC type

### DIFF
--- a/template.json
+++ b/template.json
@@ -9,7 +9,8 @@
     "builders": [{
         "type": "virtualbox-iso",
         "vboxmanage": [
-            ["modifyvm","{{.Name}}","--memory","1536"]
+            ["modifyvm","{{.Name}}","--memory","1536"],
+            ["modifyvm","{{.Name}}","--nictype1","virtio"]
         ],
         "iso_url": "{{user `B2D_ISO_FILE`}}",
         "iso_checksum_type": "md5",

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
 
   # Create a private network for accessing VM without NAT
-  config.vm.network "private_network", ip: "192.168.10.10", id: "default-network"
+  config.vm.network "private_network", ip: "192.168.10.10", id: "default-network", nic_type: "virtio"
 
   # Add bootlocal support
   if File.file?('./bootlocal.sh')


### PR DESCRIPTION
**virtio**  ("Paravirtualized Network") is used by default by boot2docker / docker-machine cli.
It provides better performance compared to the default "Intel PRO/1000 MT Server (82545EM)" adapter.

Here's one docker specific issue this will fix: https://github.com/blinkreaction/boot2docker-vagrant/issues/13
