### PR TITLE
Moving to boot2docker 1.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BOOT2DOCKER_VERSION = 1.6.2
+BOOT2DOCKER_VERSION = 1.7.0
 
 all: clean build test
 

--- a/scripts/build-custom-iso.sh
+++ b/scripts/build-custom-iso.sh
@@ -10,11 +10,14 @@ B2D_ISO_PATH="/tmp/boot2docker-orig.iso"
 NEW_B2D_ISO_PATH="/tmp/boot2docker-vagrant.iso"
 
 rm -rf "${MNT_TMP_DIR}" "${EXTRACT_DIR}" "${NEW_ISO_DIR}"
-mkdir -p "${NEW_ISO_DIR}" "${EXTRACT_DIR}" "${MNT_TMP_DIR}"
+mkdir -p "${NEW_ISO_DIR}" "${EXTRACT_DIR}" "${MNT_TMP_DIR}" /mnt/syslinux
 
 # Install some custom tools on boot2docker
-su -c "tce-load -wi mkisofs-tools.tcz" docker
-su -c "tce-load -wi syslinux.tcz" docker
+# Note that even if the install worked, tce-loa return exit code to 1...
+su -c "tce-load -w -i mkisofs-tools" docker || :
+su -c "tce-load -w -i compiletc" docker || :
+curl -L -o /tmp/syslinux.tcz http://tinycorelinux.net/6.x/x86/tcz/syslinux.tcz
+mount /tmp/syslinux.tcz /mnt/syslinux -o loop,ro
 
 # Extract the initrd.img (Linux root filesystem) from the iso
 mount "${B2D_ISO_PATH}" "${MNT_TMP_DIR}" -o loop,ro
@@ -27,7 +30,7 @@ umount "${MNT_TMP_DIR}"
 # See https://github.com/boot2docker/boot2docker/blob/master/rootfs/make_iso.sh#L38 
 mv "${NEW_ISO_DIR}/boot/initrd.img" "${EXTRACT_DIR}/initrd.xz"
 cd "${EXTRACT_DIR}"
-xz -9 --uncompress --format=lzma -d "${EXTRACT_DIR}/initrd.xz" --stdout | cpio -i -H newc -d
+/usr/local/bin/unxz -9 --format=lzma -d "${EXTRACT_DIR}/initrd.xz" --stdout | cpio -i -H newc -d
 cd -
 rm -f "${EXTRACT_DIR}/initrd.xz"
 
@@ -46,13 +49,32 @@ echo "/usr/local/etc/init.d/nfs-client start" | tee -a "${EXTRACT_DIR}/opt/bootl
 
 # Generate the new initrd.img in new iso dir
 cd "${EXTRACT_DIR}"
-find | cpio -o -H newc | xz -9 --format=lzma > "${NEW_ISO_DIR}/boot/initrd.img"
+find | cpio -o -H newc | /usr/local/bin/xz -9 --format=lzma > "${NEW_ISO_DIR}/boot/initrd.img"
 cd -
 
-# Create our new ISO in MBR-hybrid format
-mkisofs -l -J -R -V "Custom Boot2docker v$(cat ${NEW_ISO_DIR}/version)" \
-	-no-emul-boot -boot-load-size 4 \
- 	-boot-info-table -b boot/isolinux/isolinux.bin \
- 	-c boot/isolinux/boot.cat -o "${NEW_B2D_ISO_PATH}" "${NEW_ISO_DIR}"
+# Last part will need to recompile ourself xorriso since syslinux (with isohybrid) nor xorriso exists as it in TCL in 64Bits
 
-isohybrid "${NEW_B2D_ISO_PATH}"
+XORRISO_VERSION=1.4.0
+curl -L -o "/tmp/xorriso-${XORRISO_VERSION}.tar.gz" "http://www.gnu.org/software/xorriso/xorriso-${XORRISO_VERSION}.tar.gz"
+tar -x -z -f "/tmp/xorriso-${XORRISO_VERSION}.tar.gz" -C /tmp/
+cd "/tmp/xorriso-${XORRISO_VERSION}"
+./configure
+make
+make install
+cd -
+
+# Create our new ISO in MBR-hybrid format with Xorriso
+# /usr/local/bin/xorriso -l -J -R -V "Custom Boot2docker v$(cat ${NEW_ISO_DIR}/version)" \
+# 	-no-emul-boot -boot-load-size 4 \
+#  	-boot-info-table -b boot/isolinux/isolinux.bin \
+#  	-c boot/isolinux/boot.cat -o "${NEW_B2D_ISO_PATH}" "${NEW_ISO_DIR}"
+
+/usr/local/bin/xorriso  \
+    -publisher "Damien DUPORTAL" \
+    -as mkisofs \
+    -l -J -R -V "Custom Boot2Docker-v$(cat ${NEW_ISO_DIR}/version)" \
+    -no-emul-boot -boot-load-size 4 -boot-info-table \
+    -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat \
+    -isohybrid-mbr /mnt/syslinux/usr/local/share/syslinux/isohdpfx.bin \
+    -o "${NEW_B2D_ISO_PATH}" "${NEW_ISO_DIR}"
+

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
     },
     "variables": {
         "B2D_ISO_FILE": "boot2docker.iso",
-        "B2D_ISO_CHECKSUM": "7d8c43f57d04a250696129221c23cc18"
+        "B2D_ISO_CHECKSUM": "e52d0ec9b0433520232457f141c19d70"
     },
     "builders": [{
         "type": "virtualbox-iso",

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -28,7 +28,7 @@
 	vagrant ssh -c 'docker ps'
 }
 
-DOCKER_TARGET_VERSION=1.6.2
+DOCKER_TARGET_VERSION=1.7.0
 @test "Docker is version DOCKER_TARGET_VERSION=${DOCKER_TARGET_VERSION}" {
 	DOCKER_VERSION=$(vagrant ssh -c "docker version | grep 'Client version' | awk '{print \$3}'" -- -n -T)
 	[ "${DOCKER_VERSION}" == "${DOCKER_TARGET_VERSION}" ]


### PR DESCRIPTION
This PR introduce those changes :
* Moving to boot2docker 1.7.0 (and docker 1.7.0 so on)
* Compiling stuff ourselves to take in account the 64bits move (rsync, xorriso, etc.)