### PR TITLE
Add support of Parallels boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # boot2docker Vagrant Box
 
 This repository contains the scripts necessary to create a Vagrant-compatible
-[boot2docker](https://github.com/boot2docker/boot2docker) box and is compatible with Docker v1.6. 
+[boot2docker](https://github.com/boot2docker/boot2docker) box and is compatible with Docker v1.7.
 
 If you work solely with Docker, this box lets you keep your Vagrant workflow and work in the most minimal Docker environment possible.
 
@@ -20,7 +20,7 @@ On OS X, to use the docker client, follow the directions here: http://docs.docke
 ## Tips & tricks
 
 * Vagrant synced folder has been tested with :
-  * vbox shared folder : This is default sharing system
+  * Shared Folder for Virtualbox and Parallels Desktop: This is default sharing system
   * [rsync](https://docs.vagrantup.com/v2/synced-folders/rsync.html) : add this line to your Vagrantfile (it will overwrite the default vboxsf sync behaviour) :
 
     ```ruby
@@ -49,9 +49,16 @@ sudo /etc/init.d/docker restart
 sudo cp -r /var/lib/boot2docker/tls /vagrant/
 ```
 
-  Next, you need to configure your Docker environment :
-  * Export cert path: ```export DOCKER_CERT_PATH=<Absolute path to your vagrant share>/tls```
-  * Export Docker host path : ```export DOCKER_HOST=tcp://192.168.10.10:2376``` (You can also use localhost if the NAT is OK)
+Next, you need to configure your Docker environment :
+```
+# For VirtualBox provider:
+export DOCKER_CERT_PATH=`pwd`/tls
+export DOCKER_HOST=tcp://192.168.10.10:2376
+
+# For Parallels provider:
+export DOCKER_CERT_PATH=`pwd`/tls
+export DOCKER_HOST="tcp://`vagrant ssh-config | sed -n "s/[ ]*HostName[ ]*//gp"`:2376"
+```
 
 ## Building the Box
 
@@ -63,13 +70,18 @@ To build the box, first install the following prerequisites:
 
   * [Make as workflow engine](http://www.gnu.org/software/make/)
   * [Packer as vagrant basebox builder](http://www.packer.io) (at least version 0.7.5)
-  * [VirtualBox as main virtualization system](http://www.virtualbox.org) (at least version 4.3.28) [VMware and Parallels not implemented yet]
+  * [VirtualBox](http://www.virtualbox.org) (at least version 4.3.28) or [Parallels Desktop for Mac](http://www.parallels.com/products/desktop/) (version 9 or higher) [VMware is not implemented yet]
+  * [Parallels Virtualization SDK for Mac](http://www.parallels.com/download/pvsdk/) (only if you want to build the box for Parallels)
   * [curl for downloading things](http://curl.haxx.se)
   * [bats for testing](https://github.com/sstephenson/bats)
 
-Then follow the steps:
+Then run this command to build the box for VirtualBox provider:
 
 ```
-$ make
-...
+make virtualbox
+```
+or this one to build the box for Parallels provider:
+
+```
+make parallels
 ```

--- a/template.json
+++ b/template.json
@@ -40,16 +40,19 @@
         "iso_checksum_type": "md5",
         "iso_checksum": "{{user `B2D_ISO_CHECKSUM`}}",
         "boot_wait": "5s",
-        "guest_os_type": "linux",
+        "guest_os_type": "linux-2.6",
         "ssh_username": "docker",
         "ssh_password": "tcuser",
         "shutdown_command": "sudo poweroff",
-        "parallels_tools_mode": "disable"
+        "parallels_tools_mode": "disable",
+        "prlctl": [
+            ["set", "{{.Name}}", "--memsize", "1536"]
+        ]
     }],
     "provisioners": [
         {
             "type": "file",
-            "source": "boot2docker.iso",
+            "source": "{{user `B2D_ISO_FILE`}}",
             "destination": "/tmp/boot2docker-orig.iso"
         },
         {

--- a/tests/parallels/boot2docker_vagrant_parallels.bats
+++ b/tests/parallels/boot2docker_vagrant_parallels.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+DOCKER_TARGET_VERSION=1.7.0
+
+# Assume that Vagrantfile exists and basebox is added
+@test "vagrant up" {
+	run vagrant destroy -f
+	run vagrant box remove boot2docker-virtualbox-test
+	cp vagrantfile.orig Vagrantfile
+	vagrant up --provider=parallels
+}
+
+@test "vagrant ssh" {
+	vagrant ssh -c 'echo OK'
+}
+
+@test "Default ssh user has sudoers rights" {
+	[ "$(vagrant ssh -c 'sudo whoami' -- -n -T)" == "root" ]
+}
+
+@test "Docker client exists in the remote VM" {
+	vagrant ssh -c 'which docker'
+}
+
+@test "Docker is working inside the remote VM " {
+	vagrant ssh -c 'docker ps'
+}
+
+@test "Docker version is ${DOCKER_TARGET_VERSION}" {
+	DOCKER_VERSION=$(vagrant ssh -c "docker version | grep 'Client version' | awk '{print \$3}'" -- -n -T)
+	[ "${DOCKER_VERSION}" == "${DOCKER_TARGET_VERSION}" ]
+}
+
+@test "Custom bootlocal.sh script has been run at boot" {
+	[ $(vagrant ssh -c 'grep OK /tmp/token-boot-local | wc -l' -- -n -T) -eq 1 ]
+}
+
+@test "vagrant reload" {
+	vagrant reload
+}
+
+@test "Share folder is mounted" {
+	vagrant ssh -c "ls -l /vagrant/Vagrantfile"
+}
+
+@test "Default synced folder is shared via prl_fs" {
+	[ $(vagrant ssh -c 'mount | grep /vagrant | grep prl_fs | wc -l' -- -n -T) -ge 1 ]
+}
+
+@test "Rsync is installed in the VM" {
+	vagrant ssh -c "which rsync"
+}
+
+@test "NFS client is running in the VM" {
+	[ $(vagrant ssh -c 'ps aux | grep rpc.statd | wc -l' -- -n -T) -ge 1 ]
+}
+
+@test "Default synced folder is shared via NFS if B2D_NFS_SYNC is set" {
+	export B2D_NFS_SYNC=1
+	vagrant reload
+	[ $(vagrant ssh -c 'mount | grep /vagrant | grep nfs | wc -l' -- -n -T) -ge 1 ]
+	unset B2D_NFS_SYNC
+}
+
+@test "Default synced folder can be shared via rsync" {
+	sed 's/#SYNC_TOKEN/config.vm.synced_folder ".", "\/vagrant", type: "rsync"/g' vagrantfile.orig > Vagrantfile
+	vagrant reload
+	[ $( vagrant status | grep 'running' | wc -l ) -ge 1 ]
+	vagrant ssh -c "ls -l /vagrant/Vagrantfile"
+}
+
+@test "vagrant halt" {
+	vagrant halt
+}
+
+@test "destroy and cleanup" {
+	vagrant destroy -f
+	vagrant box remove boot2docker-parallels-test
+}

--- a/tests/parallels/boot2docker_vagrant_parallels.bats
+++ b/tests/parallels/boot2docker_vagrant_parallels.bats
@@ -39,12 +39,9 @@ DOCKER_TARGET_VERSION=1.7.0
 	vagrant reload
 }
 
-@test "Share folder is mounted" {
-	vagrant ssh -c "ls -l /vagrant/Vagrantfile"
-}
-
 @test "Default synced folder is shared via prl_fs" {
-	[ $(vagrant ssh -c 'mount | grep /vagrant | grep prl_fs | wc -l' -- -n -T) -ge 1 ]
+	mount_point=$(vagrant ssh -c 'mount' | grep prl_fs | awk '{ print $3 }')
+	[ $(vagrant ssh -c "ls -l ${mount_point}/Vagrantfile | wc -l" -- -n -T) -ge 1 ]
 }
 
 @test "Rsync is installed in the VM" {
@@ -58,7 +55,8 @@ DOCKER_TARGET_VERSION=1.7.0
 @test "Default synced folder is shared via NFS if B2D_NFS_SYNC is set" {
 	export B2D_NFS_SYNC=1
 	vagrant reload
-	[ $(vagrant ssh -c 'mount | grep /vagrant | grep nfs | wc -l' -- -n -T) -ge 1 ]
+	mount_point=$(vagrant ssh -c 'mount' | grep nfs | awk '{ print $3 }')
+	[ $(vagrant ssh -c "ls -l $mount_point/Vagrantfile | wc -l" -- -n -T) -ge 1 ]
 	unset B2D_NFS_SYNC
 }
 

--- a/tests/parallels/bootlocal.sh
+++ b/tests/parallels/bootlocal.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo OK > /tmp/token-boot-local

--- a/tests/parallels/vagrantfile.orig
+++ b/tests/parallels/vagrantfile.orig
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "boot2docker-parallels-test"
+  config.vm.box_url = "file://../../boot2docker_parallels.box"
+
+  #SYNC_TOKEN
+
+end

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -8,7 +8,7 @@
 	run vagrant destroy -f
 	run vagrant box remove boot2docker-virtualbox-test
 	cp vagrantfile.orig Vagrantfile
-	vagrant up
+	vagrant up --provider=virtualbox
 	[ $( vagrant status | grep 'running' | wc -l ) -ge 1 ]
 }
 

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -43,10 +43,6 @@ DOCKER_TARGET_VERSION=1.7.0
 	vagrant ssh -c 'echo OK'
 }
 
-@test "We can share folder thru vboxsf" {
-	vagrant ssh -c "ls -l /vagrant/Vagrantfile"
-}
-
 @test "Rsync is installed inside the b2d" {
 	vagrant ssh -c "which rsync"
 }
@@ -55,14 +51,16 @@ DOCKER_TARGET_VERSION=1.7.0
 	[ $(vagrant ssh -c 'ps aux | grep rpc.statd | wc -l' -- -n -T) -ge 1 ]
 }
 
-@test "We shave a default synced folder thru vboxsf instead of NFS if NO_B2D_NFS_SYNC is set" {
-	[ $(vagrant ssh -c 'df -h /vagrant | grep vagrant | grep none | wc -l' -- -n -T) -ge 1 ]
+@test "We shave a default synced folder thru vboxsf instead of NFS" {
+	mount_point=$(vagrant ssh -c 'mount' | grep vboxsf | awk '{ print $3 }')
+	[ $(vagrant ssh -c "ls -l ${mount_point}/Vagrantfile | wc -l" -- -n -T) -ge 1 ]
 }
 
 @test "We shave a NFS synced folder if B2D_NFS_SYNC is set (admin password required, will fail on Windows)" {
 	export B2D_NFS_SYNC=1
 	vagrant reload
-	[ $(vagrant ssh -c 'df -h /vagrant | grep vagrant | grep 192.168.10.1 | wc -l' -- -n -T) -ge 1 ]
+	mount_point=$(vagrant ssh -c 'mount' | grep nfs | awk '{ print $3 }')
+	[ $(vagrant ssh -c "ls -l $mount_point/Vagrantfile | wc -l" -- -n -T) -ge 1 ]
 	unset B2D_NFS_SYNC
 }
 

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -5,17 +5,19 @@ Vagrant.configure("2") do |config|
   # Used on Vagrant >= 1.7.x to disable the ssh key regeneration
   config.ssh.insert_key = false
 
-  # Use NFS folder sync by default unless we are on Windows
+  # Use NFS folder sync if env variable B2D_NFS_SYNC is set
   if ENV['B2D_NFS_SYNC']
     config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ["nolock", "vers=3", "udp"], id: "nfs-sync"
   end
 
-  # Expose the Docker ports (non secured AND secured)
-  config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
-  config.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
+  config.vm.provider "virtualbox" do |v, override|
+    # Expose the Docker ports (non secured AND secured)
+    override.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
+    override.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
 
-  # Create a private network for accessing VM without NAT
-  config.vm.network "private_network", ip: "192.168.10.10", id: "default-network", nic_type: "virtio"
+    # Create a private network for accessing VM without NAT
+    override.vm.network "private_network", ip: "192.168.10.10", id: "default-network", nic_type: "virtio"
+  end
 
   # Add bootlocal support
   if File.file?('./bootlocal.sh')

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -1,4 +1,6 @@
 Vagrant.configure("2") do |config|
+  CURRENT_DIR = File.expand_path(File.dirname(__FILE__))
+
   config.ssh.shell = "sh"
   config.ssh.username = "docker"
 
@@ -7,7 +9,9 @@ Vagrant.configure("2") do |config|
 
   # Use NFS folder sync if env variable B2D_NFS_SYNC is set
   if ENV['B2D_NFS_SYNC']
-    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ["nolock", "vers=3", "udp"], id: "nfs-sync"
+    config.vm.synced_folder ".", CURRENT_DIR, type: "nfs", mount_options: ["nolock", "vers=3", "udp"], id: "nfs-sync"
+  else
+    config.vm.synced_folder ".", CURRENT_DIR
   end
 
   config.vm.provider "virtualbox" do |v, override|


### PR DESCRIPTION
I've added some changes to templates and scripts, allowing to build boot2docker boxes for Parallels provider (https://github.com/Parallels/vagrant-parallels/).

@dduportal I really like your approach here. Do you mind that I merge some of your commits to our official boot2docker box repo (https://github.com/Parallels/boot2docker-vagrant-box)?
Our current stuff is really outdated, so I'd like to rebase it and include your scripts if you agree.
