### PR TITLE
Update Docker to v1.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
-BOOT2DOCKER_VERSION := 1.7.0
+BOOT2DOCKER_VERSION := 1.7.1
 
 B2D_ISO_FILE := boot2docker.iso
 B2D_ISO_URL := https://github.com/boot2docker/boot2docker/releases/download/v$(BOOT2DOCKER_VERSION)/boot2docker.iso
-B2D_ISO_CHECKSUM := e52d0ec9b0433520232457f141c19d70
-
-PRL_B2D_ISO_FILE := boot2docker-prl.iso
-PRL_B2D_ISO_URL := https://github.com/Parallels/boot2docker/releases/download/v1.7.0-prl-tools/boot2docker.iso
-PRL_B2D_ISO_CHECKSUM := 6b6e5ddb06ade5adcd31194674e49ce7
+B2D_ISO_CHECKSUM := 2c314e8686749097f4bd5cc215b1daa8
 
 all: parallels virtualbox
 
@@ -26,17 +22,17 @@ build-virtualbox: $(B2D_ISO_FILE)
 		-var 'B2D_ISO_CHECKSUM=${B2D_ISO_CHECKSUM}' \
 		template.json
 
-build-parallels: $(PRL_B2D_ISO_FILE)
+build-parallels: $(B2D_ISO_FILE)
 	packer build -parallel=false -only=parallels-iso \
-		-var 'B2D_ISO_FILE=${PRL_B2D_ISO_FILE}' \
-		-var 'B2D_ISO_CHECKSUM=${PRL_B2D_ISO_CHECKSUM}' \
+		-var 'B2D_ISO_FILE=${B2D_ISO_FILE}' \
+		-var 'B2D_ISO_CHECKSUM=${B2D_ISO_CHECKSUM}' \
 		template.json
 
 clean-virtualbox:
-	rm -rf *_virtualbox.box $(B2D_ISO_FILE)
+	rm -f *_virtualbox.box $(B2D_ISO_FILE)
 
 clean-parallels:
-	rm -rf *_parallels.box $(PRL_B2D_ISO_FILE)
+	rm -f *_parallels.box $(B2D_ISO_FILE)
 
 test-virtualbox:
 	@cd tests/virtualbox; bats --tap *.bats

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # boot2docker Vagrant Box
 
 This repository contains the scripts necessary to create a Vagrant-compatible
-[boot2docker](https://github.com/boot2docker/boot2docker) box and is compatible with Docker v1.7.
+[boot2docker](https://github.com/boot2docker/boot2docker) box and is compatible with Docker v1.7.1
 
 If you work solely with Docker, this box lets you keep your Vagrant workflow and work in the most minimal Docker environment possible.
 

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
     },
     "variables": {
         "B2D_ISO_FILE": "boot2docker.iso",
-        "B2D_ISO_CHECKSUM": "e52d0ec9b0433520232457f141c19d70"
+        "B2D_ISO_CHECKSUM": "2c314e8686749097f4bd5cc215b1daa8"
     },
     "builders": [{
         "type": "virtualbox-iso",

--- a/tests/parallels/boot2docker_vagrant_parallels.bats
+++ b/tests/parallels/boot2docker_vagrant_parallels.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-DOCKER_TARGET_VERSION=1.7.0
+DOCKER_TARGET_VERSION=1.7.1
 
 # Assume that Vagrantfile exists and basebox is added
 @test "vagrant up" {

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -28,7 +28,7 @@
 	vagrant ssh -c 'docker ps'
 }
 
-DOCKER_TARGET_VERSION=1.7.0
+DOCKER_TARGET_VERSION=1.7.1
 @test "Docker is version DOCKER_TARGET_VERSION=${DOCKER_TARGET_VERSION}" {
 	DOCKER_VERSION=$(vagrant ssh -c "docker version | grep 'Client version' | awk '{print \$3}'" -- -n -T)
 	[ "${DOCKER_VERSION}" == "${DOCKER_TARGET_VERSION}" ]


### PR DESCRIPTION
* Use boot2docker.iso v1.7.1
* Switch Parallels provider to the official boot2docker.iso. Starting since v1.7.1 it includes Parallels Tools pre-installed.
We don't need to use custom ISO for Parallels Desktop VMs anymore.