### PR TITLE
Implement an option for disabling private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ config.vm.synced_folder ".", "/vagrant", type: "rsync"
     $ vagrant up
     ```
 
+* Network considerations :
+  * By default, we use a NAT interfaces, which have its ports 2375 and 2376 (Docker IANA ports) forwarded to the loopback (localhost) of your physical host.
+  * Also, we provide a private network that allow direct-IP exchange from your host. This is less portable but easier to use. This usage come from the officiel docker-machine system.
+  * If you face problems (Virtualbox errors, IP overlapping, etc.) with the private network, you can disable it with an environment variable :
+
+    ```bash
+    $ export B2D_DISABLE_PRIVATE_NETWORK=1
+    $ vagrant up
+    ```
+
 * If you want to tune contents (custom profile, install tools inside the VM) that do not fit into the "vagrant provisionning" lifecycle combinded with the un-persistence of boot2docker, the "bootlocal" system has been extended :
   * The [boot2docker FaQ](https://github.com/boot2docker/boot2docker/blob/master/doc/FAQ.md) says that you can provide a custom script, named bootlocal.sh to execute things at the end of the boot.
   * We customize in order to run that script from the /vagrant share when mounted, at the end of the boot.

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -51,17 +51,24 @@ DOCKER_TARGET_VERSION=1.8.2
 	[ $(vagrant ssh -c 'ps aux | grep rpc.statd | wc -l' -- -n -T) -ge 1 ]
 }
 
-@test "We shave a default synced folder thru vboxsf instead of NFS" {
+@test "We have a default synced folder thru vboxsf instead of NFS" {
 	mount_point=$(vagrant ssh -c 'mount' | grep vboxsf | awk '{ print $3 }')
 	[ $(vagrant ssh -c "ls -l ${mount_point}/Vagrantfile | wc -l" -- -n -T) -ge 1 ]
 }
 
-@test "We shave a NFS synced folder if B2D_NFS_SYNC is set (admin password required, will fail on Windows)" {
+@test "We have a NFS synced folder if B2D_NFS_SYNC is set (admin password required, will fail on Windows)" {
 	export B2D_NFS_SYNC=1
 	vagrant reload
 	mount_point=$(vagrant ssh -c 'mount' | grep nfs | awk '{ print $3 }')
 	[ $(vagrant ssh -c "ls -l $mount_point/Vagrantfile | wc -l" -- -n -T) -ge 1 ]
 	unset B2D_NFS_SYNC
+}
+
+@test "We can disable the private network if B2D_DISABLE_PRIVATE_NETWORK is set" {
+	export B2D_DISABLE_PRIVATE_NETWORK=1
+	vagrant reload
+	[ $(vagrant ssh -c "ip addr show | grep -e 'eth.:' | wc -l" -- -n -T) -eq 1 ]
+	unset B2D_DISABLE_PRIVATE_NETWORK
 }
 
 @test "We can share folder thru rsync" {

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -19,8 +19,10 @@ Vagrant.configure("2") do |config|
     override.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
     override.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
 
-    # Create a private network for accessing VM without NAT
-    override.vm.network "private_network", ip: "192.168.10.10", id: "default-network", nic_type: "virtio"
+    if !ENV['B2D_DISABLE_PRIVATE_NETWORK']
+      # Create a private network for accessing VM without NAT
+      override.vm.network "private_network", ip: "192.168.10.10", id: "default-network", nic_type: "virtio"
+    end
   end
 
   config.vm.provision "shell", inline: "[ ! -d /vagrant ] && ln -s #{CURRENT_DIR} /vagrant || true"


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>

Tests are OK, even the new one (implemented in TDD mode : red, green)
```bash
1..16
ok 1 We can vagrant up the VM with basic settings
ok 2 Vagrant can ssh to the VM
ok 3 Default ssh user has sudoers rights
ok 4 Docker client exists in the remote VM
ok 5 Docker is working inside the remote VM 
ok 6 Docker is version DOCKER_TARGET_VERSION=1.8.2
ok 7 My bootlocal.sh script, should have been run at boot
ok 8 We can reboot the VM properly
ok 9 Rsync is installed inside the b2d
ok 10 The NFS client is started inside the VM
ok 11 We have a default synced folder thru vboxsf instead of NFS
Password:
ok 12 We have a NFS synced folder if B2D_NFS_SYNC is set (admin password required, will fail on Windows)
ok 13 We can disable the private network if B2D_DISABLE_PRIVATE_NETWORK is set
ok 14 We can share folder thru rsync
ok 15 I can stop the VM
ok 16 I can destroy and clean the VM
```