### PR TITLE
Upgrade to Boot2Docker v1.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-BOOT2DOCKER_VERSION := 1.9.1
+BOOT2DOCKER_VERSION := 1.10.0
 
 B2D_ISO_FILE := boot2docker.iso
 B2D_ISO_URL := https://github.com/boot2docker/boot2docker/releases/download/v$(BOOT2DOCKER_VERSION)/boot2docker.iso
-B2D_ISO_CHECKSUM := 669e0c5f2698188f0d48a2ed2a3e5218
+B2D_ISO_CHECKSUM := 50cf98a4e1dbfd4eab0251e41efb5025
 
 all: parallels virtualbox
 

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -3,7 +3,7 @@
 # Given i'm already in a Vagrantfile-ized folder
 # And the basebox has already been added to vagrant
 
-DOCKER_TARGET_VERSION=1.9.1
+DOCKER_TARGET_VERSION=1.10.0
 
 @test "We can vagrant up the VM with basic settings" {
 	# Ensure the VM is stopped


### PR DESCRIPTION
bats tests pass for me on VirtualBox, I don't have parallels, so I was unable to test that.